### PR TITLE
replace raw.github.com -> rawgit.com to serve js with proper content-type in index.html bookmarklet

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@ it works on other sites that use HTML5 video.</p>
 
 
 Just drag and drop this on your bookmark bar: <br/> 
-***<a href="javascript:void((function()%7Bvar%20e%3Ddocument.createElement(%27script%27)%3Be.setAttribute(%27type%27,%27text/javascript%27)%3Be.setAttribute(%27charset%27,%27UTF-8%27)%3Be.setAttribute(%27src%27,%27https://raw.github.com/ChrisCinelli/youtube-video-speed-changer-bookmarklet/master/src/youtube-video-speed-changer-bookmarklet.min.js%3Fr%3D%27%2BMath.random()*99999999)%3Bdocument.body.appendChild(e)%7D)())%3B" style="font-size:1.3em">Change Speed</a>***
+***<a href="javascript:void((function()%7Bvar%20e%3Ddocument.createElement(%27script%27)%3Be.setAttribute(%27type%27,%27text/javascript%27)%3Be.setAttribute(%27charset%27,%27UTF-8%27)%3Be.setAttribute(%27src%27,%27https://rawgit.com/ChrisCinelli/youtube-video-speed-changer-bookmarklet/master/src/youtube-video-speed-changer-bookmarklet.min.js%3Fr%3D%27%2BMath.random()*99999999)%3Bdocument.body.appendChild(e)%7D)())%3B" style="font-size:1.3em">Change Speed</a>***
 <br/><br/>
 
 <p>Remember to enable HTML5 video on YouTube at <a href="http://www.youtube.com/html5">http://www.youtube.com/html5</a></p>


### PR DESCRIPTION
fixes error "Refused to execute script from ... because its MIME type (text/plain) is not executable, and strict MIME type checking is enabled."
